### PR TITLE
Implement IStorage Factory to interact with cache and DB connectors

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -89,3 +89,33 @@ func ConnectDB() (clickhouse.Conn, error) {
 	}
 	return conn, nil
 }
+
+func (c *ClickHouseConnector) query(query string) (string, error) {
+	// not implemented yet
+	return "", nil
+}
+
+func (c *ClickHouseConnector) insert(query string) error {
+	// not implemented yet
+	return nil
+}
+
+func (c *ClickHouseConnector) delete(query string) error {
+	// not implemented yet
+	return nil
+}
+
+func (c *ClickHouseConnector) queryCache(index, partitionKey, rangeKey string) (string, error) {
+	// not implemented yet
+	return "", nil
+}
+
+func (c *ClickHouseConnector) purgeCache(index, partitionKey, rangeKey string) error {
+	// not implemented yet
+	return nil
+}
+
+func (c *ClickHouseConnector) setCache(partitionKey, rangeKey, value string) error {
+	// not implemented yet
+	return nil
+}

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -10,21 +10,41 @@ type ConnectorConfig struct {
 	Clickhouse *ClickhouseConnectorConfig
 }
 
-type StorageConnector interface {
-	Get(index, partitionKey, rangeKey string) (string, error)
-	Set(partitionKey, rangeKey, value string) error
-	Delete(index, partitionKey, rangeKey string) error
+type IStorage struct {
+	IStorageBase
+	Cache 	IStorageCache
+	DB 		IStorageDB
 }
+
+type IStorageBase interface {
+	connect() error
+	close() error
+}
+
+type IStorageCache interface {
+	queryCache(index, partitionKey, rangeKey string) (string, error)
+	setCache(partitionKey, rangeKey, value string) error
+	purgeCache(index, partitionKey, rangeKey string) error
+}
+
+type IStorageDB interface {
+	query(query string) (string, error)
+	insert(query string) error
+	delete(query string) error
+}
+
 
 func NewStorageConnector(
 	cfg *ConnectorConfig,
-) (StorageConnector, error) {
+) (IStorage, error) {
 	switch cfg.Driver {
 	case "memory":
-		return NewMemoryConnector(cfg.Memory)
+		connector, err := NewMemoryConnector(cfg.Memory)
+		return IStorage{Cache: connector}, err
 	case "clickhouse":
-		return NewClickHouseConnector(cfg.Clickhouse)
+		connector, err := NewClickHouseConnector(cfg.Clickhouse)
+		return IStorage{DB: connector, Cache: connector}, err
 	}
 
-	return nil, fmt.Errorf("invalid connector driver: %s", cfg.Driver)
+	return IStorage{}, fmt.Errorf("invalid connector driver: %s", cfg.Driver)
 }

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -34,13 +34,13 @@ func NewMemoryConnector(cfg *MemoryConnectorConfig) (*MemoryConnector, error) {
 	}, nil
 }
 
-func (m *MemoryConnector) Set(partitionKey, rangeKey, value string) error {
+func (m *MemoryConnector) setCache(partitionKey, rangeKey, value string) error {
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
 	m.cache.Add(key, value)
 	return nil
 }
 
-func (m *MemoryConnector) Get(index, partitionKey, rangeKey string) (string, error) {
+func (m *MemoryConnector) queryCache(index, partitionKey, rangeKey string) (string, error) {
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
 	value, ok := m.cache.Get(key)
 	if !ok {
@@ -49,7 +49,7 @@ func (m *MemoryConnector) Get(index, partitionKey, rangeKey string) (string, err
 	return value, nil
 }
 
-func (m *MemoryConnector) Delete(index, partitionKey, rangeKey string) error {
+func (m *MemoryConnector) purgeCache(index, partitionKey, rangeKey string) error {
 	key := fmt.Sprintf("%s:%s", partitionKey, rangeKey)
 	m.cache.Remove(key)
 	return nil


### PR DESCRIPTION
### TL;DR

Refactored storage interfaces and implemented placeholder methods for ClickHouse connector.

### What changed?

- Introduced new interfaces `IStorage`, `IStorageBase`, `IStorageCache`, and `IStorageDB` in `connector.go`.
- Updated `NewStorageConnector` function to return `IStorage` instead of `StorageConnector`.
- Added placeholder methods for ClickHouse connector in `clickhouse.go`: `query`, `insert`, `delete`, `queryCache`, `purgeCache`, and `setCache`.
- Renamed methods in `memory.go` to align with new interface: `Set` to `setCache`, `Get` to `queryCache`, and `Delete` to `purgeCache`.

### How to test?

1. Ensure all existing tests pass after the refactoring.
2. Verify that the memory connector still functions correctly with the renamed methods.
3. Check that the ClickHouse connector can be initialized without errors.
4. Attempt to use the new placeholder methods for the ClickHouse connector and confirm they return expected "not implemented" results.

### Why make this change?

This refactoring aims to create a more flexible and consistent interface for different storage connectors. By separating concerns into distinct interfaces (base, cache, and DB operations), it allows for easier implementation of new storage solutions and better organization of existing ones. The placeholder methods for ClickHouse set the groundwork for future implementation of these operations.