### PR TITLE
Refactor worker to process multiple blocks concurrently

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/thirdweb-dev/indexer/internal/common"
 )
@@ -92,27 +91,27 @@ func connectDB() (clickhouse.Conn, error) {
 	return conn, nil
 }
 
-func (c *ClickHouseConnector) InsertBlocks(blocks []types.Block) error {
+func (c *ClickHouseConnector) InsertBlocks(blocks []common.Block) error {
 	return nil
 }
 
-func (c *ClickHouseConnector) InsertTransactions(txs []types.Transaction) error {
+func (c *ClickHouseConnector) InsertTransactions(txs []common.Transaction) error {
 	return nil
 }
 
-func (c *ClickHouseConnector) InsertEvents(events []types.Log) error {
+func (c *ClickHouseConnector) InsertEvents(events []common.Log) error {
 	return nil
 }
 
-func (c *ClickHouseConnector) GetBlocks(limit int) (events []*types.Block, err error) {
+func (c *ClickHouseConnector) GetBlocks(limit int) (events []common.Block, err error) {
 	return nil, nil
 }
 
-func (c *ClickHouseConnector) GetTransactions(blockNumber uint64, limit int) (events []*types.Transaction, err error) {
+func (c *ClickHouseConnector) GetTransactions(blockNumber uint64, limit int) (events []common.Transaction, err error) {
 	return nil, nil
 }
 
-func (c *ClickHouseConnector) GetEvents(blockNumber uint64, limit int) (events []*types.Log, err error) {
+func (c *ClickHouseConnector) GetEvents(blockNumber uint64, limit int) (events []common.Log, err error) {
 	return nil, nil
 }
 

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/thirdweb-dev/indexer/internal/common"
 )
 
@@ -34,13 +33,13 @@ type IOrchestratorStorage interface {
 }
 
 type IDBStorage interface {
-	InsertBlocks(blocks []types.Block) error
-	InsertTransactions(txs []types.Transaction) error
-	InsertEvents(events []types.Log) error
+	InsertBlocks(blocks []common.Block) error
+	InsertTransactions(txs []common.Transaction) error
+	InsertEvents(events []common.Log) error
 
-	GetBlocks(limit int) (events []*types.Block, err error)
-	GetTransactions(blockNumber uint64, limit int) (events []*types.Transaction, err error)
-	GetEvents(blockNumber uint64, limit int) (events []*types.Log, err error)
+	GetBlocks(limit int) (events []common.Block, err error)
+	GetTransactions(blockNumber uint64, limit int) (events []common.Transaction, err error)
+	GetEvents(blockNumber uint64, limit int) (events []common.Log, err error)
 	GetMaxBlockNumber() (maxBlockNumber uint64, err error)
 }
 


### PR DESCRIPTION
### TL;DR

Refactored the worker, poller, and failure recoverer to improve concurrency and error handling.

### What changed?

- Introduced a new `Worker.Run()` method that processes multiple blocks concurrently.
- Updated `Poller` and `FailureRecoverer` to use the new `Worker.Run()` method.
- Removed individual goroutines for each block in favor of a more efficient batch processing approach.
- Introduced a `BlockResult` struct to encapsulate the results of processing a block.
- Improved error handling and reporting for block processing failures.
- Refactored `getBlockRange()` to return a slice of block numbers instead of start and end blocks.
- Removed the `triggerWorker()` method from both `Poller` and `FailureRecoverer`.
- Updated the `handleBlockFailures()` and `handleBlockResults()` methods to process batch results.

### Why make this change?

This refactoring aims to improve the efficiency and reliability of the indexer by:

1. Allowing storage to do batch inserts
2. Improving error handling and reporting, making it easier to identify and debug issues.
3. Simplifying the code structure, making it more maintainable and easier to understand.
4. Enhancing the ability to process blocks in batches, which should lead to better overall performance.

These changes should result in a more robust and scalable indexer that can handle high volumes of blocks more efficiently.