### PR TITLE
Implement memory storage for blocks, transactions, and events

### DIFF
--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -49,7 +49,7 @@ func NewStorageConnector(
 	switch cfg.Driver {
 	case "memory":
 		connector, err := NewMemoryConnector(cfg.Memory)
-		return IStorage{OrchestratorStorage: connector}, err
+		return IStorage{OrchestratorStorage: connector, DBStorage: connector}, err
 	case "clickhouse":
 		connector, err := NewClickHouseConnector(cfg.Clickhouse)
 		return IStorage{DBStorage: connector, OrchestratorStorage: connector}, err


### PR DESCRIPTION
### TL;DR

Implemented DBStorage interface for MemoryConnector and updated NewStorageConnector function.

### What changed?

- Added DBStorage interface implementation to MemoryConnector
- Implemented methods for inserting and retrieving blocks, transactions, and events
- Added a method to get the maximum block number
- Updated NewStorageConnector to use MemoryConnector for both OrchestratorStorage and DBStorage


### Why make this change?

This change extends the functionality of the MemoryConnector to support both OrchestratorStorage and DBStorage interfaces. It allows for in-memory storage and retrieval of blockchain data, which can be useful for testing and development purposes without the need for a separate database.