### PR TITLE
Add debug logging and enhance block polling logic

### DIFF
--- a/internal/common/rpc.go
+++ b/internal/common/rpc.go
@@ -57,18 +57,21 @@ func (rpc *RPC) checkSupportedMethods() error {
 	if err != nil {
 		return fmt.Errorf("eth_getBlockByNumber method not supported: %v", err)
 	}
+	fmt.Println("eth_getBlockByNumber method supported")
 
 	var getLogsResult interface{}
 	logsErr := rpc.RPCClient.Call(&getLogsResult, "eth_getLogs", map[string]string{"fromBlock": "0x0", "toBlock": "0x0"})
 	if logsErr != nil {
 		return fmt.Errorf("eth_getBlockByNumber method not supported: %v", logsErr)
 	}
+	fmt.Println("eth_getLogs method supported")
 
 	var traceBlockResult interface{}
 	if traceBlockErr := rpc.RPCClient.Call(&traceBlockResult, "trace_block", "latest"); traceBlockErr != nil {
-		log.Printf("Optional method trace_block not supported")
+		log.Printf("Optional method trace_block not supported: %v", traceBlockErr)
 	}
 	rpc.SupportsTraceBlock = traceBlockResult != nil
+	fmt.Printf("trace_block method supported: %v\n", rpc.SupportsTraceBlock)
 	return nil
 }
 

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -41,7 +42,7 @@ func NewMemoryConnector(cfg *MemoryConnectorConfig) (*MemoryConnector, error) {
 func (m *MemoryConnector) GetLatestPolledBlockNumber() (uint64, error) {
 	blockNumber, ok := m.cache.Get("latest_polled_block_number")
 	if !ok {
-		return 0, nil
+		return math.MaxUint64, nil // this will overflow to genesis
 	}
 	return strconv.ParseUint(blockNumber, 10, 64)
 }

--- a/internal/worker/serializer.go
+++ b/internal/worker/serializer.go
@@ -55,7 +55,12 @@ func serializeBlock(rpc common.RPC, block *types.Block) common.Block {
 		GasUsed:          big.NewInt(int64(block.GasUsed())),
 		TransactionCount: uint64(len(block.Transactions())),
 		BaseFeePerGas:    block.BaseFee(),
-		WithdrawalsRoot:  block.Header().WithdrawalsHash.Big().String(),
+		WithdrawalsRoot: func() string {
+			if block.Header().WithdrawalsHash == nil {
+				return ""
+			}
+			return block.Header().WithdrawalsHash.Big().String()
+		}(),
 	}
 }
 


### PR DESCRIPTION
### TL;DR

Added ability to set block limit for polling. Added additional logging for RPC method support checks and added safeguards for block data serialization.

### What changed?

- Added logging for RPC method support checks in `rpc.go`
- Introduced `POLL_UNTIL_BLOCK` environment variable to limit polling
- Modified block range calculation to prevent skipping the genesis block
- Updated `GetLatestPolledBlockNumber` to return `math.MaxUint64` when no block is found so next block polled will overflow to genesis
- Added a null check for `WithdrawalsHash` in block serialization

### How to test?

1. Set the `POLL_UNTIL_BLOCK` environment variable to test polling limits
2. Verify logging output for RPC method support checks
3. Ensure polling starts from genesis when no last polled block is found
4. Test block serialization with and without `WithdrawalsHash` data
