### PR TITLE
Refactor storage interface and implement query filtering

### DIFF
--- a/internal/orchestrator/commiter.go
+++ b/internal/orchestrator/commiter.go
@@ -2,9 +2,12 @@ package orchestrator
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/thirdweb-dev/indexer/internal/storage"
 )
 
 const DEFAULT_COMMITER_TRIGGER_INTERVAL = 250
@@ -13,9 +16,10 @@ const DEFAULT_BLOCKS_PER_COMMIT = 10
 type Commiter struct {
 	triggerIntervalMs int
 	blocksPerCommit   int
+	storage           storage.IStorage
 }
 
-func NewCommiter() *Commiter {
+func NewCommiter(storage storage.IStorage) *Commiter {
 	triggerInterval, err := strconv.Atoi(os.Getenv("COMMITER_TRIGGER_INTERVAL"))
 	if err != nil || triggerInterval == 0 {
 		triggerInterval = DEFAULT_COMMITER_TRIGGER_INTERVAL
@@ -27,6 +31,7 @@ func NewCommiter() *Commiter {
 	return &Commiter{
 		triggerIntervalMs: triggerInterval,
 		blocksPerCommit:   blocksPerCommit,
+		storage:           storage,
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -17,8 +17,25 @@ type Orchestrator struct {
 }
 
 func NewOrchestrator(rpc common.RPC) (*Orchestrator, error) {
-	storage, err := storage.NewStorageConnector(&storage.ConnectorConfig{
-		Driver: "memory",
+	storage, err := storage.NewStorageConnector(&storage.StorageConfig{
+		Orchestrator: storage.ConnectorConfig{
+			Driver: "memory",
+			Memory: &storage.MemoryConnectorConfig{
+				Prefix: "orchestrator",
+			},
+		},
+		Main: storage.ConnectorConfig{
+			Driver: "memory",
+			Memory: &storage.MemoryConnectorConfig{
+				Prefix: "main",
+			},
+		},
+		Staging: storage.ConnectorConfig{
+			Driver: "memory",
+			Memory: &storage.MemoryConnectorConfig{
+				Prefix: "staging",
+			},
+		},
 	})
 	if err != nil {
 		return nil, err
@@ -58,7 +75,7 @@ func (o *Orchestrator) Start() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			commiter := NewCommiter()
+			commiter := NewCommiter(o.storage)
 			commiter.Start()
 		}()
 	}

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -103,15 +103,15 @@ func (c *ClickHouseConnector) InsertEvents(events []common.Log) error {
 	return nil
 }
 
-func (c *ClickHouseConnector) GetBlocks(limit int) (events []common.Block, err error) {
+func (c *ClickHouseConnector) GetBlocks(qf QueryFilter) (events []common.Block, err error) {
 	return nil, nil
 }
 
-func (c *ClickHouseConnector) GetTransactions(blockNumber uint64, limit int) (events []common.Transaction, err error) {
+func (c *ClickHouseConnector) GetTransactions(qf QueryFilter) (events []common.Transaction, err error) {
 	return nil, nil
 }
 
-func (c *ClickHouseConnector) GetEvents(blockNumber uint64, limit int) (events []common.Log, err error) {
+func (c *ClickHouseConnector) GetEvents(qf QueryFilter) (events []common.Log, err error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
### TL;DR

Refactored storage system to support multiple storage instances and improved query filtering.

Note that intellisense won't show it if a storageConnector is not implementing the needed interface. But it will throw at runtime. This change was made to not have the switch clause duplicated. If that's not important, we can create multiple functions (one for each interface) so that editors can understand type inference

### What changed?

- Introduced `StorageConfig` with separate configurations for Main, Staging, and Orchestrator storage.
- Added `QueryFilter` struct for more flexible querying of blocks, transactions, and events.
- Updated `IStorage` interface to include separate storage instances for different purposes.
- Modified `NewStorageConnector` to create multiple storage instances based on the new config.
- Implemented `newConnector` function for type-safe connector creation.
- Updated `MemoryConnector` and `ClickHouseConnector` to use the new `QueryFilter` in their query methods.
- Added helper functions in `memory.go` for handling query filters and key matching.
- Updated `Commiter` to accept a storage instance in its constructor.


### Why make this change?

This refactoring improves the flexibility and scalability of the storage system by:

1. Allowing separate storage configurations for different purposes (Main, Staging, Orchestrator).
2. Providing more granular control over queries with the `QueryFilter` struct.
3. Enhancing type safety and reducing potential runtime errors with the new connector creation process.
4. Improving the overall structure and maintainability of the storage-related code.