### PR TITLE
unify-logs-naming-with-db

### DIFF
--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -42,11 +42,11 @@ type IOrchestratorStorage interface {
 type IDBStorage interface {
 	InsertBlocks(blocks []common.Block) error
 	InsertTransactions(txs []common.Transaction) error
-	InsertLogs(events []common.Log) error
+	InsertLogs(logs []common.Log) error
 
-	GetBlocks(qf QueryFilter) (events []common.Block, err error)
-	GetTransactions(qf QueryFilter) (events []common.Transaction, err error)
-	GetEvents(qf QueryFilter) (events []common.Log, err error)
+	GetBlocks(qf QueryFilter) (logs []common.Block, err error)
+	GetTransactions(qf QueryFilter) (logs []common.Transaction, err error)
+	GetLogs(qf QueryFilter) (logs []common.Log, err error)
 	GetMaxBlockNumber() (maxBlockNumber uint64, err error)
 
 	DeleteBlocks(blocks []common.Block) error

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -154,8 +154,8 @@ func (m *MemoryConnector) GetTransactions(qf QueryFilter) ([]common.Transaction,
 	return txs, nil
 }
 
-func (m *MemoryConnector) InsertLogs(events []common.Log) error {
-	for _, event := range events {
+func (m *MemoryConnector) InsertLogs(logs []common.Log) error {
+	for _, event := range logs {
 		eventJson, err := json.Marshal(event)
 		if err != nil {
 			return err
@@ -165,12 +165,12 @@ func (m *MemoryConnector) InsertLogs(events []common.Log) error {
 	return nil
 }
 
-func (m *MemoryConnector) GetEvents(qf QueryFilter) ([]common.Log, error) {
-	events := []common.Log{}
+func (m *MemoryConnector) GetLogs(qf QueryFilter) ([]common.Log, error) {
+	logs := []common.Log{}
 	limit := getLimit(qf)
 	blockNumbersToCheck := getBlockNumbersToCheck(qf)
 	for _, key := range m.cache.Keys() {
-		if len(events) >= limit {
+		if len(logs) >= limit {
 			break
 		}
 		if isKeyForBlock(key, "event:", blockNumbersToCheck) {
@@ -181,11 +181,11 @@ func (m *MemoryConnector) GetEvents(qf QueryFilter) ([]common.Log, error) {
 				if err != nil {
 					return nil, err
 				}
-				events = append(events, event)
+				logs = append(logs, event)
 			}
 		}
 	}
-	return events, nil
+	return logs, nil
 }
 
 func (m *MemoryConnector) GetMaxBlockNumber() (uint64, error) {


### PR DESCRIPTION
### TL;DR

Renamed 'events' to 'logs' for consistency and clarity in storage-related functions.

### What changed?

- Renamed parameter 'events' to 'logs' in `InsertLogs` function
- Changed `GetEvents` function to `GetLogs`
- Updated variable names from 'events' to 'logs' in affected functions
- Modified function signatures in the `IDBStorage` interface to reflect these changes

### How to test?

1. Ensure all calls to `InsertLogs` now use 'logs' instead of 'events' as the parameter name
2. Verify that `GetLogs` is called instead of `GetEvents` throughout the codebase
3. Check that the `IDBStorage` interface is implemented correctly in all storage connectors
4. Run existing tests to confirm that the functionality remains unchanged

### Why make this change?

This change improves code consistency and readability by using the term 'logs' instead of 'events' when referring to blockchain log entries. This aligns better with Ethereum terminology and reduces potential confusion between events and logs in the codebase.