### PR TITLE
fixed delete logs and renaming

### DIFF
--- a/internal/orchestrator/commiter.go
+++ b/internal/orchestrator/commiter.go
@@ -141,7 +141,7 @@ func (c *Commiter) getStagingDataForBlocks(blockNumbers []uint64) (logs []common
 
 	go func() {
 		defer wg.Done()
-		logs, logErr = c.storage.DBStagingStorage.GetEvents(storage.QueryFilter{BlockNumbers: blockNumbers})
+		logs, logErr = c.storage.DBStagingStorage.GetLogs(storage.QueryFilter{BlockNumbers: blockNumbers})
 	}()
 
 	go func() {
@@ -179,7 +179,7 @@ func (c *Commiter) saveDataToMainStorage(blocks []common.Block, logs []common.Lo
 
 	go func() {
 		defer commitWg.Done()
-		if err := c.storage.DBMainStorage.InsertEvents(logs); err != nil {
+		if err := c.storage.DBMainStorage.InsertLogs(logs); err != nil {
 			commitErrMutex.Lock()
 			commitErr = fmt.Errorf("error inserting logs: %v", err)
 			commitErrMutex.Unlock()
@@ -231,7 +231,7 @@ func (c *Commiter) deleteDataFromStagingStorage(blocks []common.Block, logs []co
 
 	go func() {
 		defer deleteWg.Done()
-		if err := c.storage.DBStagingStorage.DeleteEvents(logs); err != nil {
+		if err := c.storage.DBStagingStorage.DeleteLogs(logs); err != nil {
 			deleteErrMutex.Lock()
 			deleteErr = fmt.Errorf("error deleting logs from staging: %v", err)
 			deleteErrMutex.Unlock()

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -163,18 +163,18 @@ func (c *ClickHouseConnector) InsertLogs(logs []common.Log) error {
 	if err != nil {
 		return err
 	}
-	for _, event := range logs {
+	for _, log := range logs {
 		err := batch.Append(
-			event.ChainId,
-			event.BlockNumber,
-			event.BlockHash,
-			event.BlockTimestamp,
-			event.TransactionHash,
-			event.TransactionIndex,
-			event.Index,
-			event.Address,
-			event.Data,
-			event.Topics,
+			log.ChainId,
+			log.BlockNumber,
+			log.BlockHash,
+			log.BlockTimestamp,
+			log.TransactionHash,
+			log.TransactionIndex,
+			log.Index,
+			log.Address,
+			log.Data,
+			log.Topics,
 		)
 		if err != nil {
 			return err
@@ -282,14 +282,14 @@ func (c *ClickHouseConnector) DeleteTransactions(txs []common.Transaction) error
 	return batch.Send()
 }
 
-func (c *ClickHouseConnector) DeleteEvents(events []common.Log) error {
+func (c *ClickHouseConnector) DeleteLogs(logs []common.Log) error {
 	batch, err := c.conn.PrepareBatch(context.Background(), "DELETE FROM " + c.cfg.Database + ".logs")
 	if err != nil {
 		return err
 	}
 
-	for _, event := range events {
-		err := batch.Append(event.TransactionHash, event.Index)
+	for _, log := range logs {
+		err := batch.Append(log.BlockNumber, log.TransactionHash, log.Index)
 		if err != nil {
 			return err
 		}
@@ -343,24 +343,24 @@ func (c *ClickHouseConnector) GetLogs(qf QueryFilter) (logs []common.Log, err er
 	defer rows.Close()
 	
 	for rows.Next() {
-		var event common.Log
+		var log common.Log
 		err := rows.Scan(
-			&event.ChainId,
-			&event.BlockNumber,
-			&event.BlockHash,
-			&event.BlockTimestamp,
-			&event.TransactionHash,
-			&event.TransactionIndex,
-			&event.Index,
-			&event.Address,
-			&event.Data,
-			&event.Topics,
+			&log.ChainId,
+			&log.BlockNumber,
+			&log.BlockHash,
+			&log.BlockTimestamp,
+			&log.TransactionHash,
+			&log.TransactionIndex,
+			&log.Index,
+			&log.Address,
+			&log.Data,
+			&log.Topics,
 		)
 		if err != nil {
 			log.Error(err.Error())
 			return nil, err
 		}
-		logs = append(logs, event)
+		logs = append(logs, log)
 	}
 	return logs, nil
 }

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -51,7 +51,7 @@ type IDBStorage interface {
 
 	DeleteBlocks(blocks []common.Block) error
 	DeleteTransactions(txs []common.Transaction) error
-	DeleteEvents(events []common.Log) error
+	DeleteLogs(logs []common.Log) error
 }
 
 func NewStorageConnector(cfg *StorageConfig) (IStorage, error) {

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -155,12 +155,12 @@ func (m *MemoryConnector) GetTransactions(qf QueryFilter) ([]common.Transaction,
 }
 
 func (m *MemoryConnector) InsertLogs(logs []common.Log) error {
-	for _, event := range logs {
-		eventJson, err := json.Marshal(event)
+	for _, log := range logs {
+		logJson, err := json.Marshal(log)
 		if err != nil {
 			return err
 		}
-		m.cache.Add(fmt.Sprintf("event:%s-%d", event.TransactionHash, event.Index), string(eventJson))
+		m.cache.Add(fmt.Sprintf("log:%s-%d", log.TransactionHash, log.Index), string(logJson))
 	}
 	return nil
 }
@@ -173,15 +173,15 @@ func (m *MemoryConnector) GetLogs(qf QueryFilter) ([]common.Log, error) {
 		if len(logs) >= limit {
 			break
 		}
-		if isKeyForBlock(key, "event:", blockNumbersToCheck) {
+		if isKeyForBlock(key, "log:", blockNumbersToCheck) {
 			value, ok := m.cache.Get(key)
 			if ok {
-				event := common.Log{}
-				err := json.Unmarshal([]byte(value), &event)
+				log := common.Log{}
+				err := json.Unmarshal([]byte(value), &log)
 				if err != nil {
 					return nil, err
 				}
-				logs = append(logs, event)
+				logs = append(logs, log)
 			}
 		}
 	}
@@ -249,9 +249,9 @@ func (m *MemoryConnector) DeleteTransactions(txs []common.Transaction) error {
 	return nil
 }
 
-func (m *MemoryConnector) DeleteEvents(events []common.Log) error {
-	for _, event := range events {
-		m.cache.Remove(fmt.Sprintf("event:%s-%d", event.TransactionHash, event.Index))
+func (m *MemoryConnector) DeleteLogs(logs []common.Log) error {
+	for _, log := range logs {
+		m.cache.Remove(fmt.Sprintf("log:%s-%d", log.TransactionHash, log.Index))
 	}
 	return nil
 }


### PR DESCRIPTION
### TL;DR

Renamed "events" to "logs" throughout the codebase for consistency and clarity.

### What changed?

- Updated function names and variables in `commiter.go`, `clickhouse.go`, `connector.go`, and `memory.go` files.
- Replaced "event" with "log" in variable names, function parameters, and comments.
- Modified database queries and cache keys to use "log" instead of "event".
- Updated the `DeleteLogs` function to include `BlockNumber` in the deletion criteria.

### How to test?

1. Run unit tests for the affected files to ensure functionality remains intact.
2. Test the storage operations (insert, get, delete) for logs in both ClickHouse and memory storage.
3. Verify that the orchestrator correctly handles log data throughout its lifecycle.
4. Check that existing queries and data manipulations still work as expected with the new naming convention.

### Why make this change?

This change improves code consistency and clarity by using the term "logs" instead of "events" throughout the codebase. In blockchain terminology, "logs" is a more accurate term for the data being handled, as it specifically refers to the event logs generated by smart contracts. This renaming helps prevent confusion and aligns the codebase with industry-standard terminology.