### PR TITLE
Separate interface for staging storage

### DIFF
--- a/internal/common/block.go
+++ b/internal/common/block.go
@@ -28,3 +28,10 @@ type Block struct {
 	WithdrawalsRoot  string
 	BaseFeePerGas    uint64
 }
+
+type BlockData struct {
+	Block        Block
+	Transactions []Transaction
+	Logs         []Log
+	Traces       []Trace
+}

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -529,3 +529,15 @@ func getBlockNumbersStringArray(blockNumbers []*big.Int) string {
 	}
 	return blockNumbersString
 }
+
+func (c *ClickHouseConnector) InsertBlockData(data []common.BlockData) error {
+	return nil
+}
+
+func (c *ClickHouseConnector) GetBlockData(blockNumbers []*big.Int) (data []common.BlockData, err error) {
+	return nil, nil
+}
+
+func (c *ClickHouseConnector) DeleteBlockData(blockNumbers []*big.Int) error {
+	return nil
+}

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -265,3 +265,15 @@ func (m *MemoryConnector) DeleteLogs(logs []common.Log) error {
 	}
 	return nil
 }
+
+func (m *MemoryConnector) InsertBlockData(data []common.BlockData) error {
+	return nil
+}
+
+func (m *MemoryConnector) GetBlockData(blockNumbers []*big.Int) (data []common.BlockData, err error) {
+	return nil, nil
+}
+
+func (m *MemoryConnector) DeleteBlockData(blockNumbers []*big.Int) error {
+	return nil
+}


### PR DESCRIPTION
### TL;DR

Created a separate interface for staging storage.
Introduced a new `BlockData` structure and refactored the committer and poller to use it, improving data handling efficiency.

### What changed?

- Added a new `BlockData` struct in `block.go` to encapsulate block-related information.
- Refactored the `Commiter` to work with `BlockData` instead of separate block components.
- Updated the `Poller` to use `BlockData` when handling block results.
- Modified storage interfaces to support operations with `BlockData`.
- Simplified data insertion and deletion processes in staging and main storage.