### PR TITLE
Implement block data storage

### DIFF
--- a/internal/common/block_failures.go
+++ b/internal/common/block_failures.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"encoding/json"
-	"fmt"
 	"math/big"
 	"time"
 )
@@ -13,49 +11,4 @@ type BlockFailure struct {
 	FailureTime   time.Time
 	FailureReason string
 	FailureCount  int
-}
-
-func BlockFailureToString(blockFailure BlockFailure) (string, error) {
-	type Alias BlockFailure
-	marshalled, err := json.Marshal(&struct {
-		*Alias
-		BlockNumber string `json:"block_number"`
-		ChainId     string `json:"chain_id"`
-	}{
-		Alias:       (*Alias)(&blockFailure),
-		ChainId:     blockFailure.ChainId.String(),
-		BlockNumber: blockFailure.BlockNumber.String(),
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal block failure: %v", err)
-	}
-	return string(marshalled), nil
-}
-
-func StringToBlockFailure(blockFailureJson string) (BlockFailure, error) {
-	var result BlockFailure
-	type Alias BlockFailure
-	aux := &struct {
-		*Alias
-		ChainId     string `json:"chain_id"`
-		BlockNumber string `json:"block_number"`
-	}{
-		Alias: (*Alias)(&result),
-	}
-
-	err := json.Unmarshal([]byte(blockFailureJson), &aux)
-	if err != nil {
-		return result, fmt.Errorf("failed to unmarshal block failure: %v", err)
-	}
-
-	chainId, ok := new(big.Int).SetString(aux.ChainId, 10)
-	if !ok {
-		return result, fmt.Errorf("failed to parse chain id: %s", aux.ChainId)
-	}
-	result.ChainId = chainId
-	result.BlockNumber, ok = new(big.Int).SetString(aux.BlockNumber, 10)
-	if !ok {
-		return result, fmt.Errorf("failed to parse block number: %s", aux.BlockNumber)
-	}
-	return result, nil
 }

--- a/internal/tools/clickhouse_create_blocks_table.sql
+++ b/internal/tools/clickhouse_create_blocks_table.sql
@@ -26,3 +26,4 @@ CREATE TABLE base.blocks (
     INDEX idx_number number TYPE minmax GRANULARITY 1,
 ) ENGINE = ReplacingMergeTree(insert_timestamp, is_deleted)
 ORDER BY (chain_id, hash) PRIMARY KEY (chain_id, hash)
+SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;

--- a/internal/tools/clickhouse_create_logs_table.sql
+++ b/internal/tools/clickhouse_create_logs_table.sql
@@ -27,3 +27,4 @@ CREATE TABLE base.logs (
     is_deleted
 )
 ORDER BY (block_number, transaction_hash, log_index) SETTINGS index_granularity = 8192
+SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;

--- a/internal/tools/clickhouse_create_staging_table.sql
+++ b/internal/tools/clickhouse_create_staging_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE staging.block_data (
+    `chain_id` UInt256,
+    `block_number` UInt256,
+    `data` String,
+    `insert_timestamp` DateTime DEFAULT now(),
+    `is_deleted` UInt8 DEFAULT 0,
+    INDEX idx_block_number block_number TYPE minmax GRANULARITY 1,
+) ENGINE = ReplacingMergeTree(insert_timestamp, is_deleted)
+ORDER BY (chain_id, block_number) PRIMARY KEY (chain_id, block_number)
+SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;

--- a/internal/tools/clickhouse_create_traces_table.sql
+++ b/internal/tools/clickhouse_create_traces_table.sql
@@ -30,3 +30,4 @@ CREATE TABLE base.traces (
     is_deleted
 )
 ORDER BY (block_number) SETTINGS index_granularity = 8192
+SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;

--- a/internal/tools/clickhouse_create_transactions_table.sql
+++ b/internal/tools/clickhouse_create_transactions_table.sql
@@ -26,3 +26,4 @@ CREATE TABLE base.transactions (
     is_deleted
 )
 ORDER BY (chain_id, block_number) SETTINGS index_granularity = 8192
+SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;


### PR DESCRIPTION
### TL;DR

Implemented block data storage and retrieval functionality, and optimized ClickHouse table configurations.

### What changed?

- Removed `BlockFailureToString` and `StringToBlockFailure` functions from `block_failures.go` as they are unnecessary.
- Implemented `InsertBlockData`, `GetBlockData`, and `DeleteBlockData` methods in both ClickHouse and Memory connectors.
- Added `FINAL` keyword to ClickHouse SELECT queries for improved data consistency. 
- Updated ClickHouse table creation scripts to include `allow_experimental_replacing_merge_with_cleanup` setting. [Read more here](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replacingmergetree)
- Added a new SQL script for creating a `block_data` table in the staging schema.
- Modified block and transaction key formats in the Memory connector to use string representations of block numbers.

### How to test?

1. Run the updated ClickHouse table creation scripts to ensure the new settings are applied.
2. Test the new `InsertBlockData`, `GetBlockData`, and `DeleteBlockData` methods in both ClickHouse and Memory connectors.
3. Verify that the `FINAL` keyword in ClickHouse SELECT queries returns the most up-to-date data.
4. Check that block and transaction retrieval in the Memory connector works correctly with the new key formats.

### Why make this change?

These changes improve data storage and retrieval efficiency, enhance data consistency in ClickHouse queries, and provide a more robust mechanism for handling block data. The addition of the `allow_experimental_replacing_merge_with_cleanup` setting optimizes the ClickHouse table engine for better performance and data management.