### PR TITLE
Add trace processing and optimize ClickHouse table structures

### DIFF
--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -64,9 +64,9 @@ func (p *Poller) Start() {
 	ticker := time.NewTicker(interval)
 
 	go func() {
-		for t := range ticker.C {
-			log.Debug().Msgf("Poller running at %s", t)
+		log.Debug().Msgf("Poller running")
 
+		for range ticker.C {
 			blockNumbers, err := p.getBlockRange()
 			var endBlock *big.Int
 			if len(blockNumbers) > 0 {

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -50,10 +50,12 @@ type IMainStorage interface {
 	InsertBlocks(blocks []common.Block) error
 	InsertTransactions(txs []common.Transaction) error
 	InsertLogs(logs []common.Log) error
+	InsertTraces(traces []common.Trace) error
 
 	GetBlocks(qf QueryFilter) (logs []common.Block, err error)
 	GetTransactions(qf QueryFilter) (logs []common.Transaction, err error)
 	GetLogs(qf QueryFilter) (logs []common.Log, err error)
+	GetTraces(qf QueryFilter) (traces []common.Trace, err error)
 	GetMaxBlockNumber() (maxBlockNumber *big.Int, err error)
 }
 

--- a/internal/tools/clickhouse_create_logs_table.sql
+++ b/internal/tools/clickhouse_create_logs_table.sql
@@ -20,11 +20,6 @@ CREATE TABLE base.logs (
     INDEX topic1_idx topic_1 TYPE bloom_filter GRANULARITY 1,
     INDEX topic2_idx topic_2 TYPE bloom_filter GRANULARITY 1,
     INDEX topic3_idx topic_3 TYPE bloom_filter GRANULARITY 1,
-) ENGINE = SharedReplacingMergeTree(
-    '/clickhouse/tables/{uuid}/{shard}',
-    '{replica}',
-    insert_timestamp,
-    is_deleted
-)
-ORDER BY (block_number, transaction_hash, log_index) SETTINGS index_granularity = 8192
+) ENGINE = SharedReplacingMergeTree(insert_timestamp, is_deleted)
+ORDER BY (block_number, transaction_hash, log_index)
 SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;

--- a/internal/tools/clickhouse_create_traces_table.sql
+++ b/internal/tools/clickhouse_create_traces_table.sql
@@ -23,11 +23,5 @@ CREATE TABLE base.traces (
     INDEX hash_idx transaction_hash TYPE bloom_filter GRANULARITY 1,
     INDEX to_address_idx to_address TYPE bloom_filter GRANULARITY 1,
     INDEX from_address_idx from_address TYPE bloom_filter GRANULARITY 1,
-) ENGINE = SharedReplacingMergeTree(
-    '/clickhouse/tables/{uuid}/{shard}',
-    '{replica}',
-    insert_timestamp,
-    is_deleted
-)
-ORDER BY (block_number) SETTINGS index_granularity = 8192
-SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;
+) ENGINE = ReplacingMergeTree(insert_timestamp, is_deleted)
+ORDER BY (block_number, id) SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;

--- a/internal/tools/clickhouse_create_transactions_table.sql
+++ b/internal/tools/clickhouse_create_transactions_table.sql
@@ -19,11 +19,5 @@ CREATE TABLE base.transactions (
     `insert_timestamp` DateTime DEFAULT now(),
     INDEX block_timestamp_idx block_timestamp TYPE minmax GRANULARITY 1,
     INDEX transaction_hash_idx hash TYPE bloom_filter GRANULARITY 1,
-) ENGINE = SharedReplacingMergeTree(
-    '/clickhouse/tables/{uuid}/{shard}',
-    '{replica}',
-    insert_timestamp,
-    is_deleted
-)
-ORDER BY (chain_id, block_number) SETTINGS index_granularity = 8192
-SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;
+) ENGINE = ReplacingMergeTree(insert_timestamp, is_deleted)
+ORDER BY (chain_id, block_number, hash) SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;


### PR DESCRIPTION
### TL;DR

Added support for trace data storage and retrieval in the ClickHouse and Memory connectors.

### What changed?

- Updated the `Commiter` to handle trace data insertion
- Modified the `ClickHouseConnector` and `MemoryConnector` to include `InsertTraces` and `GetTraces` methods
- Added trace-related functionality to the `IMainStorage` interface
- Updated SQL scripts for creating ClickHouse tables, including a new traces table
- Adjusted engine types and order by clauses for better performance in ClickHouse tables

### How to test?

1. Run the updated SQL scripts to create or modify the ClickHouse tables
2. Verify that trace data is being inserted correctly by checking the `traces` table
3. Test the `GetTraces` method to ensure proper retrieval of trace data
4. Confirm that the `Commiter` is successfully handling trace data alongside blocks, transactions, and logs

### Why make this change?

This change enhances the system's capability to store and retrieve trace data, which is crucial for more comprehensive blockchain analysis. By including trace information, users can gain deeper insights into contract interactions and internal transactions within the blockchain ecosystem.