### PR TITLE
Implement GetLogs queries without grouping and filter columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ go.work.sum
 # env file
 .env
 
+# dev files
+cmd/api/__debug_bin*
 .vscode
 
 configs/secrets*

--- a/api/api.go
+++ b/api/api.go
@@ -39,9 +39,9 @@ type Meta struct {
 }
 
 type QueryResponse struct {
-	Meta Meta          `json:"meta"`
-	Data []interface{} `json:"data"`
-	Aggregations map[string]interface{} `json:"aggregations,omitempty"`
+	Meta         Meta                   `json:"meta"`
+	Data         interface{}            `json:"data,omitempty"`
+	Aggregations map[string]string      `json:"aggregations,omitempty"`
 }
 
 func writeError(w http.ResponseWriter, message string, code int) {
@@ -75,7 +75,12 @@ func ParseQueryParams(r *http.Request) (QueryParams, error) {
 	params.FilterParams = make(map[string]string)
 	for key, values := range rawQueryParams {
 		if strings.HasPrefix(key, "filter_") {
-			params.FilterParams[key] = values[0]
+			// TODO: tmp hack remove it once we implement filtering with operators
+			strippedKey := strings.Replace(key, "filter_", "", 1)
+			if strippedKey == "event_name" {
+				strippedKey = "data"
+			}
+			params.FilterParams[strippedKey] = values[0]
 			delete(rawQueryParams, key)
 		}
 	}

--- a/internal/handlers/logs_handlers.go
+++ b/internal/handlers/logs_handlers.go
@@ -56,7 +56,7 @@ func handleLogsRequest(w http.ResponseWriter, r *http.Request, contractAddress, 
 
 	logs, err := mainStorage.GetLogs(storage.QueryFilter{
 		FilterParams:    queryParams.FilterParams,
-		GroupBy:         queryParams.GroupBy,
+		GroupBy:         []string{queryParams.GroupBy},
 		SortBy:          queryParams.SortBy,
 		SortOrder:       queryParams.SortOrder,
 		Page:            queryParams.Page,
@@ -81,10 +81,8 @@ func handleLogsRequest(w http.ResponseWriter, r *http.Request, contractAddress, 
 			TotalItems:      0, // TODO: Implement total items count
 			TotalPages:      0, // TODO: Implement total pages count
 		},
-		Data: []interface{}{logs},
-		Aggregations: map[string]interface{}{
-			"aggregates": queryParams.Aggregates,
-		},
+		Data:         logs.Data,
+		Aggregations: logs.Aggregates,
 	}
 
 	sendJSONResponse(w, response)

--- a/internal/handlers/transactions_handlers.go
+++ b/internal/handlers/transactions_handlers.go
@@ -46,7 +46,7 @@ func handleTransactionsRequest(w http.ResponseWriter, r *http.Request, contractA
 
 	transactions, err := mainStorage.GetTransactions(storage.QueryFilter{
 		FilterParams:    queryParams.FilterParams,
-		GroupBy:         queryParams.GroupBy,
+		GroupBy:         []string{queryParams.GroupBy},
 		SortBy:          queryParams.SortBy,
 		SortOrder:       queryParams.SortOrder,
 		Page:            queryParams.Page,
@@ -71,10 +71,8 @@ func handleTransactionsRequest(w http.ResponseWriter, r *http.Request, contractA
 			TotalItems:      0, // TODO: Implement total items count
 			TotalPages:      0, // TODO: Implement total pages count
 		},
-		Data: []interface{}{transactions},
-		Aggregations: map[string]interface{}{
-			"aggregates": queryParams.Aggregates,
-		},
+		Data: transactions,
+		// Aggregations: queryParams.Aggregates,
 	}
 
 	sendJSONResponse(w, response)

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -11,7 +11,7 @@ import (
 type QueryFilter struct {
 	BlockNumbers    []*big.Int
 	FilterParams    map[string]string
-	GroupBy         string
+	GroupBy         []string
 	SortBy          string
 	SortOrder       string
 	Page            int
@@ -20,7 +20,10 @@ type QueryFilter struct {
 	ContractAddress string
 	FunctionSig     string
 }
-
+type QueryResult struct {
+	Data       []common.Log      `json:"data"`
+	Aggregates map[string]string `json:"aggregates"`
+}
 type IStorage struct {
 	OrchestratorStorage IOrchestratorStorage
 	MainStorage         IMainStorage
@@ -50,7 +53,7 @@ type IMainStorage interface {
 
 	GetBlocks(qf QueryFilter) (logs []common.Block, err error)
 	GetTransactions(qf QueryFilter) (logs []common.Transaction, err error)
-	GetLogs(qf QueryFilter) (logs []common.Log, err error)
+	GetLogs(qf QueryFilter) (logs QueryResult, err error)
 	GetTraces(qf QueryFilter) (traces []common.Trace, err error)
 	GetMaxBlockNumber() (maxBlockNumber *big.Int, err error)
 }


### PR DESCRIPTION
### TL;DR

Updated API response structure, improved query filtering, and added aggregation support for logs.

### What changed?

- Modified `QueryResponse` structure in `api.go` to use `interface{}` for `Data` field and `map[string]string` for `Aggregations`.
- Updated `ParseQueryParams` function to handle `event_name` filter.
- Changed `GroupBy` parameter in `QueryFilter` to accept an array of strings.
- Refactored `GetLogs` function in `clickhouse.go` to support advanced filtering, sorting, and aggregations.
- Updated `IMainStorage` interface to return `QueryResult` instead of `[]common.Log` for `GetLogs`.
- Added debug binary files to `.gitignore`.

### How to test?

1. Run the API and make requests to the logs endpoint with various query parameters.
2. Test filtering using `filter_event_name` and other filter parameters.
3. Verify that grouping, sorting, and pagination work as expected.
4. Check if aggregations are correctly calculated and returned in the response.

### Why make this change?

These changes improve the flexibility and functionality of the API, allowing for more complex queries and data analysis. The updated structure supports better filtering, aggregation, and response formatting, which enhances the overall usability of the API for clients.