### PR TITLE
Improve initial block setting logic in poller

### DIFF
--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -41,7 +41,7 @@ func NewPoller(rpc common.RPC, storage storage.IStorage) *Poller {
 	}
 	pollFromBlock := big.NewInt(int64(config.Cfg.Poller.FromBlock))
 	lastPolledBlock, err := storage.StagingStorage.GetLastStagedBlockNumber()
-	if err != nil || lastPolledBlock == nil {
+	if err != nil || lastPolledBlock == nil || lastPolledBlock.Sign() <= 0 {
 		lastPolledBlock = new(big.Int).Sub(pollFromBlock, big.NewInt(1)) // needs to include the first block
 		log.Warn().Err(err).Msgf("No last polled block found, setting to %s", lastPolledBlock.String())
 	} else {


### PR DESCRIPTION
### TL;DR

Improved initial block selection logic in the Poller constructor.

### What changed?

Modified the condition for setting the `lastPolledBlock` in the `NewPoller` function. Now, it also checks if the `lastPolledBlock` is less than the `pollFromBlock` configuration value. If true, it resets the `lastPolledBlock` to one block before the `pollFromBlock`.

