### PR TITLE
Fill gaps when detected at the begining of a commit batch

### DIFF
--- a/internal/orchestrator/committer.go
+++ b/internal/orchestrator/committer.go
@@ -15,8 +15,8 @@ import (
 	"github.com/thirdweb-dev/indexer/internal/storage"
 )
 
-const DEFAULT_COMMITTER_TRIGGER_INTERVAL = 250
-const DEFAULT_BLOCKS_PER_COMMIT = 10
+const DEFAULT_COMMITTER_TRIGGER_INTERVAL = 2000
+const DEFAULT_BLOCKS_PER_COMMIT = 1000
 
 type Committer struct {
 	triggerIntervalMs int
@@ -70,17 +70,19 @@ func (c *Committer) Start() {
 }
 
 func (c *Committer) getBlockNumbersToCommit() ([]*big.Int, error) {
-	maxBlockNumber, err := c.storage.MainStorage.GetMaxBlockNumber()
+	latestCommittedBlockNumber, err := c.storage.MainStorage.GetMaxBlockNumber()
+	log.Info().Msgf("Committer found this max block number in main storage: %s", latestCommittedBlockNumber.String())
 	if err != nil {
 		return nil, err
 	}
 
-	if maxBlockNumber.Cmp(big.NewInt(0)) == 0 {
-		maxBlockNumber = new(big.Int).Sub(c.pollFromBlock, big.NewInt(1))
+	if latestCommittedBlockNumber.Cmp(big.NewInt(0)) == 0 {
+		// If no blocks have been committed yet, start from the fromBlock specified in the config (same start for the poller)
+		latestCommittedBlockNumber = c.pollFromBlock
 	}
 
-	startBlock := new(big.Int).Add(maxBlockNumber, big.NewInt(1))
-	endBlock := new(big.Int).Add(maxBlockNumber, big.NewInt(int64(c.blocksPerCommit)))
+	startBlock := new(big.Int).Add(latestCommittedBlockNumber, big.NewInt(1))
+	endBlock := new(big.Int).Add(latestCommittedBlockNumber, big.NewInt(int64(c.blocksPerCommit)))
 
 	blockCount := new(big.Int).Sub(endBlock, startBlock).Int64() + 1
 	blockNumbers := make([]*big.Int, blockCount)
@@ -105,6 +107,7 @@ func (c *Committer) getSequentialBlockDataToCommit() ([]common.BlockData, error)
 		return nil, fmt.Errorf("error fetching blocks to commit: %v", err)
 	}
 	if len(blocksData) == 0 {
+		log.Warn().Msgf("Committer didn't find the following range in staging: %v - %v", blocksToCommit[0].Int64(), blocksToCommit[len(blocksToCommit)-1].Int64())
 		return nil, nil
 	}
 
@@ -114,7 +117,16 @@ func (c *Committer) getSequentialBlockDataToCommit() ([]common.BlockData, error)
 	})
 
 	if blocksData[0].Block.Number.Cmp(blocksToCommit[0]) != 0 {
-		// we are missing first block in staging, meaning whole batch cannot be committed
+		// we are missing block(s) in the beginning of the batch in staging, let's fill the gap
+		blockFailures := make([]common.BlockData, 0, len(blocksToCommit))
+		for _, blockNumber := range blocksToCommit {
+			blockFailures = append(blockFailures, common.BlockData{
+				Block: common.Block{
+					Number: blockNumber,
+				},
+			})
+		}
+		c.addBlocksToFailureDetector(blockFailures)
 		return nil, fmt.Errorf("first block number (%s) in commit batch does not match expected (%s)", blocksData[0].Block.Number.String(), blocksToCommit[0].String())
 	}
 
@@ -125,6 +137,9 @@ func (c *Committer) getSequentialBlockDataToCommit() ([]common.BlockData, error)
 	for i := 1; i < len(blocksData); i++ {
 		if blocksData[i].Block.Number.Cmp(expectedBlockNumber) != 0 {
 			// Gap detected, stop here
+			log.Warn().Msgf("Gap detected at block %s, stopping commit", expectedBlockNumber.String())
+			// add the blocknumber to the failure detector
+			c.addBlocksToFailureDetector(blocksData[i:])
 			break
 		}
 		sequentialBlockData = append(sequentialBlockData, blocksData[i])
@@ -132,6 +147,25 @@ func (c *Committer) getSequentialBlockDataToCommit() ([]common.BlockData, error)
 	}
 
 	return sequentialBlockData, nil
+}
+
+func (c *Committer) addBlocksToFailureDetector(blocksData []common.BlockData) {
+	
+	blockFailures := make([]common.BlockFailure, 0, len(blocksData))
+	for _, block := range blocksData {
+		blockFailures = append(blockFailures, common.BlockFailure{
+			BlockNumber: block.Block.Number,
+			FailureCount: 1,
+			FailureTime:   time.Now(),
+			FailureReason: "Gap detected",
+		})
+	}
+
+	c.storage.OrchestratorStorage.StoreBlockFailures(blockFailures)
+	// increment the a gap counter in prometheus
+	gapCounter.Inc()
+	// record the first missed block number in prometheus
+	missedBlockNumbers.Set(float64(blocksData[0].Block.Number.Int64()))
 }
 
 func (c *Committer) commit(blockData []common.BlockData) error {
@@ -231,5 +265,15 @@ var (
 	lastCommittedBlock = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "committer_last_committed_block",
 		Help: "The last successfully committed block number",
+	})
+
+	gapCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "committer_gap_counter",
+		Help: "The number of gaps detected during commits",
+	})
+
+	missedBlockNumbers = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "committer_first_missed_block_number",
+		Help: "The first blocknumber detected in a commit gap",
 	})
 )

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog/log"
 	config "github.com/thirdweb-dev/indexer/configs"
 	"github.com/thirdweb-dev/indexer/internal/common"
@@ -173,6 +175,7 @@ func (p *Poller) handleWorkerResults(results []worker.WorkerResult) {
 				Error:       e,
 			})
 		}
+		polledBatchSize.Set(float64(len(blockData)))
 	}
 
 	if len(failedResults) > 0 {
@@ -199,3 +202,10 @@ func (p *Poller) handleBlockFailures(results []worker.WorkerResult) {
 		log.Error().Err(err).Msg("Error saving block failures")
 	}
 }
+
+var (
+	polledBatchSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "polled_batch_size",
+		Help: "The number of blocks polled in a single batch",
+	})
+)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -70,7 +70,7 @@ func (w *Worker) Run(blockNumbers []*big.Int) []WorkerResult {
 	var wg sync.WaitGroup
 	resultsCh := make(chan []WorkerResult, len(chunks))
 
-	log.Debug().Msgf("Processing %d blocks in %d chunks of max %d blocks", blockCount, len(chunks), w.rpc.BlocksPerRequest.Blocks)
+	log.Debug().Msgf("Worker Processing %d blocks in %d chunks of max %d blocks", blockCount, len(chunks), w.rpc.BlocksPerRequest.Blocks)
 	for _, chunk := range chunks {
 		wg.Add(1)
 		go func(chunk []*big.Int) {


### PR DESCRIPTION
### TL;DR

Improved committer performance and added failure recovery mechanisms.

### What changed?

- Increased `DEFAULT_COMMITTER_TRIGGER_INTERVAL` from 250 to 2000 and `DEFAULT_BLOCKS_PER_COMMIT` from 10 to 1000.
- Enhanced logging for better visibility into committer operations.
- Implemented gap detection and failure handling in the committer process.
- Added new Prometheus metrics for tracking gaps and missed blocks.
- Improved the FailureRecoverer to handle block recovery more efficiently.
- Added Prometheus metrics for the FailureRecoverer to track its progress.
- Enhanced the Poller with a new metric to track batch sizes.

### How to test?

1. Run the indexer with the new changes.
2. Monitor the new Prometheus metrics:
   - `committer_gap_counter`
   - `committer_first_missed_block_number`
   - `failure_recoverer_last_triggered_block`
   - `failure_recoverer_first_block_in_batch`
   - `polled_batch_size`
3. Verify that gaps are detected and handled correctly by the committer.
4. Check that the FailureRecoverer is triggered for missed blocks and recovers them successfully.

### Why make this change?

These changes aim to improve the overall performance and reliability of the indexer by:

1. Increasing the commit batch size for better efficiency.
2. Implementing robust gap detection and recovery mechanisms to ensure data consistency.
3. Adding more detailed logging and metrics for better observability and debugging.
4. Enhancing the failure recovery process to handle missed blocks more effectively.

These improvements will lead to a more stable and performant indexing process, reducing data inconsistencies and improving the system's ability to recover from failures.