### PR TITLE
Encapsulate porometheus metrics in a package

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Committer Metrics
+var (
+	SuccessfulCommits = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "committer_successful_commits_total",
+		Help: "The total number of successful block commits",
+	})
+
+	LastCommittedBlock = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "committer_last_committed_block",
+		Help: "The last successfully committed block number",
+	})
+
+	GapCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "committer_gap_counter",
+		Help: "The number of gaps detected during commits",
+	})
+
+	MissedBlockNumbers = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "committer_first_missed_block_number",
+		Help: "The first blocknumber detected in a commit gap",
+	})
+)
+
+// Worker Metrics
+var LastFetchedBlock = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "worker_last_fetched_block_from_rpc",
+	Help: "The last block number fetched by the worker from the RPC",
+})
+
+// Poller metrics
+var (
+	PolledBatchSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "polled_batch_size",
+		Help: "The number of blocks polled in a single batch",
+	})
+)
+
+// Failure Recoverer Metrics
+var (
+	FailureRecovererLastTriggeredBlock = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "failure_recoverer_last_triggered_block",
+		Help: "The last block number that the failure recoverer was triggered for",
+	})
+
+	FirstBlocknumberInFailureRecovererBatch = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "failure_recoverer_first_block_in_batch",
+		Help: "The first block number in the failure recoverer batch",
+	})
+)

--- a/internal/orchestrator/failure_recoverer.go
+++ b/internal/orchestrator/failure_recoverer.go
@@ -4,11 +4,10 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog/log"
 	config "github.com/thirdweb-dev/indexer/configs"
 	"github.com/thirdweb-dev/indexer/internal/common"
+	"github.com/thirdweb-dev/indexer/internal/metrics"
 	"github.com/thirdweb-dev/indexer/internal/storage"
 	"github.com/thirdweb-dev/indexer/internal/worker"
 )
@@ -70,8 +69,8 @@ func (fr *FailureRecoverer) Start() {
 			fr.handleWorkerResults(blockFailures, results)
 
 			// Track recovery activity
-			failureRecovererLastTriggeredBlock.Set(float64(blockFailures[len(blockFailures)-1].BlockNumber.Int64()))
-			firstBlocknumberInfailureRecovererBatch.Set(float64(blockFailures[0].BlockNumber.Int64()))
+			metrics.FailureRecovererLastTriggeredBlock.Set(float64(blockFailures[len(blockFailures)-1].BlockNumber.Int64()))
+			metrics.FirstBlocknumberInFailureRecovererBatch.Set(float64(blockFailures[0].BlockNumber.Int64()))
 		}
 	}()
 
@@ -109,15 +108,3 @@ func (fr *FailureRecoverer) handleWorkerResults(blockFailures []common.BlockFail
 	}
 	fr.storage.OrchestratorStorage.StoreBlockFailures(newBlockFailures)
 }
-
-var (
-	failureRecovererLastTriggeredBlock = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "failure_recoverer_last_triggered_block",
-		Help: "The last block number that the failure recoverer was triggered for",
-	})
-
-	firstBlocknumberInfailureRecovererBatch = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "failure_recoverer_first_block_in_batch",
-		Help: "The first block number in the failure recoverer batch",
-	})
-)

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -7,11 +7,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog/log"
 	config "github.com/thirdweb-dev/indexer/configs"
 	"github.com/thirdweb-dev/indexer/internal/common"
+	"github.com/thirdweb-dev/indexer/internal/metrics"
 	"github.com/thirdweb-dev/indexer/internal/storage"
 	"github.com/thirdweb-dev/indexer/internal/worker"
 )
@@ -175,7 +174,7 @@ func (p *Poller) handleWorkerResults(results []worker.WorkerResult) {
 				Error:       e,
 			})
 		}
-		polledBatchSize.Set(float64(len(blockData)))
+		metrics.PolledBatchSize.Set(float64(len(blockData)))
 	}
 
 	if len(failedResults) > 0 {
@@ -202,10 +201,3 @@ func (p *Poller) handleBlockFailures(results []worker.WorkerResult) {
 		log.Error().Err(err).Msg("Error saving block failures")
 	}
 }
-
-var (
-	polledBatchSize = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "polled_batch_size",
-		Help: "The number of blocks polled in a single batch",
-	})
-)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog/log"
 	config "github.com/thirdweb-dev/indexer/configs"
 	"github.com/thirdweb-dev/indexer/internal/common"
+	"github.com/thirdweb-dev/indexer/internal/metrics"
 )
 
 type Worker struct {
@@ -95,7 +94,7 @@ func (w *Worker) Run(blockNumbers []*big.Int) []WorkerResult {
 	if len(results) > 0 {
 		// dividing by 10 to avoid scientific notation (e.g. 1.23456e+07)
 		// TODO: find a solution
-		lastFetchedBlock.Set(float64(results[len(results)-1].BlockNumber.Uint64()) / 10)
+		metrics.LastFetchedBlock.Set(float64(results[len(results)-1].BlockNumber.Uint64()) / 10)
 	}
 	return results
 }
@@ -219,9 +218,3 @@ func fetchBatch[T any](RPC common.RPC, blockNumbers []*big.Int, method string, a
 
 	return results
 }
-
-// Add a gauge to track the fetched block numbers in Prometheus
-var lastFetchedBlock = promauto.NewGauge(prometheus.GaugeOpts{
-	Name: "worker_last_fetched_block_from_rpc",
-	Help: "The last block number fetched by the worker from the RPC",
-})	


### PR DESCRIPTION
### TL;DR

Centralized Prometheus metrics in a new package and updated references across the codebase.

### What changed?

- Created a new `metrics` package in `internal/metrics/metrics.go`
- Moved all Prometheus metric definitions to the new package
- Updated references to metrics in `committer.go`, `failure_recoverer.go`, `poller.go`, and `worker.go`
- Removed local metric definitions from individual files

### How to test?

1. Ensure all existing metrics are still being recorded correctly
2. Verify that the application compiles and runs without errors
3. Check that Prometheus is able to scrape the metrics as before
4. Confirm that no metrics are duplicated or missing

### Why make this change?

This change improves code organization and maintainability by:

1. Centralizing all metric definitions in one location
2. Reducing code duplication
3. Making it easier to add, modify, or remove metrics in the future
4. Improving consistency in how metrics are defined and used across the codebase