### PR TITLE
Add range end parameter to GetLastStagedBlockNumber

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -490,8 +490,11 @@ func (c *ClickHouseConnector) GetMaxBlockNumber() (maxBlockNumber *big.Int, err 
 	return maxBlockNumber, nil
 }
 
-func (c *ClickHouseConnector) GetLastStagedBlockNumber() (maxBlockNumber *big.Int, err error) {
+func (c *ClickHouseConnector) GetLastStagedBlockNumber(rangeEnd *big.Int) (maxBlockNumber *big.Int, err error) {
 	query := fmt.Sprintf("SELECT max(block_number) FROM %s.block_data FINAL WHERE is_deleted = 0", c.cfg.Database)
+	if rangeEnd.Sign() > 0 {
+		query += fmt.Sprintf(" AND block_number <= %s", rangeEnd.String())
+	}
 	err = c.conn.QueryRow(context.Background(), query).Scan(&maxBlockNumber)
 	if err != nil {
 		return nil, err

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -43,7 +43,7 @@ type IStagingStorage interface {
 	InsertBlockData(data []common.BlockData) error
 	GetBlockData(qf QueryFilter) (data []common.BlockData, err error)
 	DeleteBlockData(data []common.BlockData) error
-	GetLastStagedBlockNumber() (maxBlockNumber *big.Int, err error)
+	GetLastStagedBlockNumber(rangeEnd *big.Int) (maxBlockNumber *big.Int, err error)
 }
 
 type IMainStorage interface {

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -193,7 +193,14 @@ func (m *MemoryConnector) GetMaxBlockNumber() (*big.Int, error) {
 	return maxBlockNumber, nil
 }
 
-func (m *MemoryConnector) GetLastStagedBlockNumber() (*big.Int, error) {
+func IsInRange(num *big.Int, rangeEnd *big.Int) bool {
+	if rangeEnd.Sign() == 0 {
+		return true
+	}
+	return num.Cmp(rangeEnd) <= 0
+}
+
+func (m *MemoryConnector) GetLastStagedBlockNumber(rangeEnd *big.Int) (*big.Int, error) {
 	maxBlockNumber := new(big.Int)
 	for _, key := range m.cache.Keys() {
 		if strings.HasPrefix(key, "blockData:") {
@@ -202,7 +209,7 @@ func (m *MemoryConnector) GetLastStagedBlockNumber() (*big.Int, error) {
 			if !ok {
 				return nil, fmt.Errorf("failed to parse block number: %s", blockNumberStr)
 			}
-			if blockNumber.Cmp(maxBlockNumber) > 0 {
+			if blockNumber.Cmp(maxBlockNumber) > 0 && IsInRange(blockNumber, rangeEnd) {
 				maxBlockNumber = blockNumber
 			}
 		}


### PR DESCRIPTION
### TL;DR

Implemented range-based block number retrieval in the poller and storage components.

### What changed?

- Modified `GetLastStagedBlockNumber` function to accept a `rangeEnd` parameter in both ClickHouse and Memory connectors.
- Updated the `Poller` to use the new `untilBlock` parameter when retrieving the last staged block number.
- Added a range check in the Memory connector to ensure the returned block number is within the specified range.
- Adjusted the ClickHouse query to include a range condition when `rangeEnd` is provided.

### How to test?

1. Set different values for `Poller.UntilBlock` in the configuration.
2. Run the poller and verify that it correctly retrieves the last staged block number within the specified range.
3. Test with both ClickHouse and Memory storage to ensure consistent behavior.
4. Verify that the poller respects the `untilBlock` limit when processing blocks.

### Why make this change?

This change allows for more precise control over the block range processed by the poller and thus allows us to run multiple pollers for different ranges at a time. By implementing a range-based retrieval of the last staged block number, we can ensure that the poller operates within specified block boundaries, improving flexibility and preventing potential issues with processing blocks beyond the intended range.