### PR TITLE
Switch block_time to unix timestamp

### DIFF
--- a/internal/common/block.go
+++ b/internal/common/block.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"math/big"
-	"time"
 )
 
 type Block struct {
@@ -10,7 +9,7 @@ type Block struct {
 	Number           *big.Int  `json:"number"`
 	Hash             string    `json:"hash"`
 	ParentHash       string    `json:"parent_hash"`
-	Timestamp        time.Time `json:"timestamp"`
+	Timestamp        uint64    `json:"timestamp"`
 	Nonce            string    `json:"nonce"`
 	Sha3Uncles       string    `json:"sha3_uncles"`
 	MixHash          string    `json:"mix_hash"`

--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -2,14 +2,13 @@ package common
 
 import (
 	"math/big"
-	"time"
 )
 
 type Log struct {
 	ChainId          *big.Int  `json:"chain_id"`
 	BlockNumber      *big.Int  `json:"block_number"`
 	BlockHash        string    `json:"block_hash"`
-	BlockTimestamp   time.Time `json:"block_timestamp"`
+	BlockTimestamp   uint64    `json:"block_timestamp"`
 	TransactionHash  string    `json:"transaction_hash"`
 	TransactionIndex uint64    `json:"transaction_index"`
 	LogIndex         uint64    `json:"log_index"`

--- a/internal/common/trace.go
+++ b/internal/common/trace.go
@@ -2,14 +2,13 @@ package common
 
 import (
 	"math/big"
-	"time"
 )
 
 type Trace struct {
 	ChainID          *big.Int  `json:"chain_id"`
 	BlockNumber      *big.Int  `json:"block_number"`
 	BlockHash        string    `json:"block_hash"`
-	BlockTimestamp   time.Time `json:"block_timestamp"`
+	BlockTimestamp   uint64    `json:"block_timestamp"`
 	TransactionHash  string    `json:"transaction_hash"`
 	TransactionIndex uint64    `json:"transaction_index"`
 	Subtraces        int64     `json:"subtraces"`

--- a/internal/common/transaction.go
+++ b/internal/common/transaction.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"math/big"
-	"time"
 )
 
 type Transaction struct {
@@ -11,7 +10,7 @@ type Transaction struct {
 	Nonce                uint64    `json:"nonce"`
 	BlockHash            string    `json:"block_hash"`
 	BlockNumber          *big.Int  `json:"block_number"`
-	BlockTimestamp       time.Time `json:"block_timestamp"`
+	BlockTimestamp       uint64 `json:"block_timestamp"`
 	TransactionIndex     uint64    `json:"transaction_index"`
 	FromAddress          string    `json:"from_address"`
 	ToAddress            string    `json:"to_address"`

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -72,7 +71,7 @@ func (c *ClickHouseConnector) InsertBlocks(blocks []common.Block) error {
 		err := batch.Append(
 			block.ChainId,
 			block.Number,
-			uint64(block.Timestamp.Unix()),
+			block.Timestamp,
 			block.Hash,
 			block.ParentHash,
 			block.Sha3Uncles,
@@ -119,7 +118,7 @@ func (c *ClickHouseConnector) InsertTransactions(txs []common.Transaction) error
 			tx.Nonce,
 			tx.BlockHash,
 			tx.BlockNumber,
-			uint64(tx.BlockTimestamp.Unix()),
+			tx.BlockTimestamp,
 			tx.TransactionIndex,
 			tx.FromAddress,
 			tx.ToAddress,
@@ -158,7 +157,7 @@ func (c *ClickHouseConnector) InsertLogs(logs []common.Log) error {
 			log.ChainId,
 			log.BlockNumber,
 			log.BlockHash,
-			uint64(log.BlockTimestamp.Unix()),
+			log.BlockTimestamp,
 			log.TransactionHash,
 			log.TransactionIndex,
 			log.LogIndex,
@@ -230,13 +229,12 @@ func (c *ClickHouseConnector) GetBlocks(qf QueryFilter) (blocks []common.Block, 
 
 	for rows.Next() {
 		var block common.Block
-		var timestamp uint64
 		err := rows.Scan(
 			&block.ChainId,
 			&block.Number,
 			&block.Hash,
 			&block.ParentHash,
-			&timestamp,
+			&block.Timestamp,
 			&block.Nonce,
 			&block.Sha3Uncles,
 			&block.LogsBloom,
@@ -255,7 +253,6 @@ func (c *ClickHouseConnector) GetBlocks(qf QueryFilter) (blocks []common.Block, 
 			zLog.Error().Err(err).Msg("Error scanning block")
 			return nil, err
 		}
-		block.Timestamp = time.Unix(int64(timestamp), 0)
 		blocks = append(blocks, block)
 	}
 	return blocks, nil
@@ -343,20 +340,20 @@ func addFilterParams(key, value, query string) string {
 
 	suffix := key[len(key)-3:]
 	switch suffix {
-		case "gte":
-			query += fmt.Sprintf(" AND %s >= '%s'", key[:len(key)-3], value)
-		case "lte":
-			query += fmt.Sprintf(" AND %s <= '%s'", key[:len(key)-3], value)
-		case "_lt":
-			query += fmt.Sprintf(" AND %s < '%s'", key[:len(key)-3], value)
-		case "_gt":
-			query += fmt.Sprintf(" AND %s > '%s'", key[:len(key)-3], value)
-		case "_ne":
-			query += fmt.Sprintf(" AND %s != '%s'", key[:len(key)-3], value)
-		case "_in":
-			query += fmt.Sprintf(" AND %s IN (%s)", key[:len(key)-3], value)
-		default:
-			query += fmt.Sprintf(" AND %s = '%s'", key, value)
+	case "gte":
+		query += fmt.Sprintf(" AND %s >= '%s'", key[:len(key)-3], value)
+	case "lte":
+		query += fmt.Sprintf(" AND %s <= '%s'", key[:len(key)-3], value)
+	case "_lt":
+		query += fmt.Sprintf(" AND %s < '%s'", key[:len(key)-3], value)
+	case "_gt":
+		query += fmt.Sprintf(" AND %s > '%s'", key[:len(key)-3], value)
+	case "_ne":
+		query += fmt.Sprintf(" AND %s != '%s'", key[:len(key)-3], value)
+	case "_in":
+		query += fmt.Sprintf(" AND %s IN (%s)", key[:len(key)-3], value)
+	default:
+		query += fmt.Sprintf(" AND %s = '%s'", key, value)
 	}
 	return query
 }
@@ -414,14 +411,13 @@ func (c *ClickHouseConnector) executeAggregateQuery(table string, qf QueryFilter
 
 func scanTransaction(rows driver.Rows) (common.Transaction, error) {
 	var tx common.Transaction
-	var timestamp uint64
 	err := rows.Scan(
 		&tx.ChainId,
 		&tx.Hash,
 		&tx.Nonce,
 		&tx.BlockHash,
 		&tx.BlockNumber,
-		&timestamp,
+		&tx.BlockTimestamp,
 		&tx.TransactionIndex,
 		&tx.FromAddress,
 		&tx.ToAddress,
@@ -440,19 +436,17 @@ func scanTransaction(rows driver.Rows) (common.Transaction, error) {
 	if err != nil {
 		return common.Transaction{}, fmt.Errorf("error scanning transaction: %w", err)
 	}
-	tx.BlockTimestamp = time.Unix(int64(timestamp), 0)
 	return tx, nil
 }
 
 func scanLog(rows driver.Rows) (common.Log, error) {
 	var log common.Log
-	var timestamp uint64
 	var topics [4]string
 	err := rows.Scan(
 		&log.ChainId,
 		&log.BlockNumber,
 		&log.BlockHash,
-		&timestamp,
+		&log.BlockTimestamp,
 		&log.TransactionHash,
 		&log.TransactionIndex,
 		&log.LogIndex,
@@ -466,7 +460,6 @@ func scanLog(rows driver.Rows) (common.Log, error) {
 	if err != nil {
 		return common.Log{}, fmt.Errorf("error scanning log: %w", err)
 	}
-	log.BlockTimestamp = time.Unix(int64(timestamp), 0)
 	for _, topic := range topics {
 		if topic != "" {
 			log.Topics = append(log.Topics, topic)
@@ -645,7 +638,7 @@ func (c *ClickHouseConnector) InsertTraces(traces []common.Trace) error {
 			trace.ChainID,
 			trace.BlockNumber,
 			trace.BlockHash,
-			uint64(trace.BlockTimestamp.Unix()),
+			trace.BlockTimestamp,
 			trace.TransactionHash,
 			trace.TransactionIndex,
 			trace.Subtraces,
@@ -684,12 +677,11 @@ func (c *ClickHouseConnector) GetTraces(qf QueryFilter) (traces []common.Trace, 
 
 	for rows.Next() {
 		var trace common.Trace
-		var timestamp uint64
 		err := rows.Scan(
 			&trace.ChainID,
 			&trace.BlockNumber,
 			&trace.BlockHash,
-			&timestamp,
+			&trace.BlockTimestamp,
 			&trace.TransactionHash,
 			&trace.TransactionIndex,
 			&trace.Subtraces,
@@ -712,7 +704,6 @@ func (c *ClickHouseConnector) GetTraces(qf QueryFilter) (traces []common.Trace, 
 			zLog.Error().Err(err).Msg("Error scanning transaction")
 			return nil, err
 		}
-		trace.BlockTimestamp = time.Unix(int64(timestamp), 0)
 		traces = append(traces, trace)
 	}
 	return traces, nil

--- a/internal/worker/serializer.go
+++ b/internal/worker/serializer.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"math/big"
 	"strconv"
-	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/thirdweb-dev/indexer/internal/common"
@@ -68,7 +67,7 @@ func serializeBlock(chainId *big.Int, block RawBlock) common.Block {
 		Number:           hexToBigInt(block["number"]),
 		Hash:             interfaceToString(block["hash"]),
 		ParentHash:       interfaceToString(block["parentHash"]),
-		Timestamp:        hexSecondsTimestampToTime(block["timestamp"]),
+		Timestamp:        hexToUint64(block["timestamp"]),
 		Nonce:            interfaceToString(block["nonce"]),
 		Sha3Uncles:       interfaceToString(block["sha3Uncles"]),
 		MixHash:          interfaceToString(block["mixHash"]),
@@ -89,7 +88,7 @@ func serializeBlock(chainId *big.Int, block RawBlock) common.Block {
 	}
 }
 
-func serializeTransactions(chainId *big.Int, transactions []interface{}, blockTimestamp time.Time) []common.Transaction {
+func serializeTransactions(chainId *big.Int, transactions []interface{}, blockTimestamp uint64) []common.Transaction {
 	if len(transactions) == 0 {
 		return []common.Transaction{}
 	}
@@ -100,7 +99,7 @@ func serializeTransactions(chainId *big.Int, transactions []interface{}, blockTi
 	return serializedTransactions
 }
 
-func serializeTransaction(chainId *big.Int, rawTx interface{}, blockTimestamp time.Time) common.Transaction {
+func serializeTransaction(chainId *big.Int, rawTx interface{}, blockTimestamp uint64) common.Transaction {
 	tx, ok := rawTx.(map[string]interface{})
 	if !ok {
 		log.Debug().Msgf("Failed to serialize transaction: %v", rawTx)
@@ -238,11 +237,6 @@ func hexToUint64(hex interface{}) uint64 {
 	}
 	v, _ := strconv.ParseUint(hexString[2:], 16, 64)
 	return v
-}
-
-func hexSecondsTimestampToTime(hexTimestamp interface{}) time.Time {
-	timestamp := int64(hexToUint64(hexTimestamp))
-	return time.Unix(timestamp, 0)
 }
 
 func interfaceToString(value interface{}) string {


### PR DESCRIPTION
### TL;DR

Changed timestamp representation from `time.Time` to `uint64` across multiple structs and functions.

### What changed?

- Modified `Block`, `Log`, `Trace`, and `Transaction` structs to use `uint64` for timestamp fields instead of `time.Time`.
- Updated `ClickHouseConnector` methods to handle `uint64` timestamps directly, removing `time.Unix()` conversions.
- Adjusted `serializeBlock` and `serializeTransaction` functions to work with `uint64` timestamps.
- Removed `hexSecondsTimestampToTime` function as it's no longer needed.
- Removed `time` import from affected files.

### How to test?

1. Run unit tests for affected structs and functions.
2. Perform integration tests with ClickHouse to ensure proper data insertion and retrieval.
3. Verify that timestamp-related operations in the application still work correctly with the new `uint64` representation.

### Why make this change?

Using `uint64` for timestamps instead of `time.Time` offers several benefits:

1. Improved performance by reducing type conversions.
2. Simplified data handling and storage in ClickHouse.
3. Consistent representation of timestamps across the application.
4. Reduced memory usage by using a more compact data type.

This change aligns the timestamp representation with common blockchain standards and optimizes data processing throughout the indexer.