### PR TITLE
Adjust block polling logic and improve ClickHouse data handling

### DIFF
--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -50,7 +50,7 @@ func NewPoller(rpc common.RPC, storage storage.IStorage) *Poller {
 		// In the case where the start block in staging introduces a gap with main storage,
 		// This hack allows us to re-poll from the start block without having to delete the staging data
 		if config.Cfg.Poller.ForceFromBlock {
-			lastPolledBlock = pollFromBlock
+			lastPolledBlock = new(big.Int).Sub(pollFromBlock, big.NewInt(1)) // needs to include the first block
 		}
 		log.Info().Msgf("Last polled block found: %s", lastPolledBlock.String())
 	}

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -211,7 +211,7 @@ func (c *ClickHouseConnector) StoreBlockFailures(failures []common.BlockFailure)
 		err := batch.Append(
 			failure.ChainId,
 			failure.BlockNumber,
-			failure.FailureTime,
+			uint64(failure.FailureTime.Unix()),
 			failure.FailureCount,
 			failure.FailureReason,
 		)
@@ -502,17 +502,19 @@ func (c *ClickHouseConnector) GetLastStagedBlockNumber() (maxBlockNumber *big.In
 func scanBlockFailure(rows driver.Rows) (common.BlockFailure, error) {
 	var failure common.BlockFailure
 	var timestamp uint64
+	var count uint16
 	err := rows.Scan(
 		&failure.ChainId,
 		&failure.BlockNumber,
 		&timestamp,
-		&failure.FailureCount,
+		&count,
 		&failure.FailureReason,
 	)
 	if err != nil {
 		return common.BlockFailure{}, fmt.Errorf("error scanning block failure: %w", err)
 	}
 	failure.FailureTime = time.Unix(int64(timestamp), 0)
+	failure.FailureCount = int(count)
 	return failure, nil
 }
 


### PR DESCRIPTION
This PR addresses several issues and makes improvements to the poller and storage components:

1. Poller Adjustment:
   - Modified the `NewPoller` function to correctly include the first block when `ForceFromBlock` is enabled.

2. ClickHouseConnector Updates:
   - Changed the `StoreBlockFailures` method to store the failure time as a Unix timestamp.
   - Updated the `scanBlockFailure` function to:
     - Convert the timestamp back to a `time.Time` object.
     - Store the failure count as an `int` instead of `uint16`.

These changes improve the accuracy of block polling and enhance the consistency of data storage and retrieval in the ClickHouse database.